### PR TITLE
Use TEST_TMPDIR for the powershell cache when available

### DIFF
--- a/powershell/private/entrypoint.bat
+++ b/powershell/private/entrypoint.bat
@@ -63,6 +63,13 @@ exit /b 0
 call :rlocation "{PWSH_INTERPRETER}" PWSH_INTERPRETER
 call :rlocation "{MAIN}" MAIN
 
+# Powershell tries to cache files in the user's `HOME` directory. When running
+# tests, try to contain this cache to an isolated location.
+if defined TEST_TMPDIR (
+    set "HOME=%TEST_TMPDIR%\powershell"
+    set "USERPROFILE=%TEST_TMPDIR%\powershell"
+)
+
 %PWSH_INTERPRETER% ^
     %MAIN% ^
     %*

--- a/powershell/private/entrypoint.sh
+++ b/powershell/private/entrypoint.sh
@@ -19,6 +19,12 @@ fi
 
 runfiles_export_envvars
 
+# Powershell tries to cache files in the user's `HOME` directory. When running
+# tests, try to contain this cache to an isolated location.
+if [[ -n "${TEST_TMPDIR}" ]]; then
+    export HOME="${TEST_TMPDIR}/powershell"
+fi
+
 exec \
     "$(rlocation "{PWSH_INTERPRETER}")" \
     "$(rlocation "{MAIN}")" \


### PR DESCRIPTION
This is an attempt to avoid the following error
```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //powershell/private/tests/test:string_test
-----------------------------------------------------------------------------
Unhandled exception. System.TypeInitializationException: The type initializer for 'System.Management.Automation.Configuration.PowerShellConfig' threw an exception.
 ---> System.TypeInitializationException: The type initializer for 'System.Management.Automation.Platform' threw an exception.
 ---> System.IO.IOException: Read-only file system : '/var/lib/buildkite-agent/.cache/powershell'
   at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
   at System.IO.Directory.CreateDirectory(String path)
   at System.Management.Automation.Platform.SelectProductNameForDirectory(XDG_Type dirpath)
   at System.Management.Automation.Platform..cctor()
   --- End of inner exception stack trace ---
   at System.Management.Automation.Configuration.PowerShellConfig..ctor()
   at System.Management.Automation.Configuration.PowerShellConfig..cctor()
   --- End of inner exception stack trace ---
   at System.Management.Automation.Utils.GetPolicySettingFromConfigFile[T](ConfigScope[] preferenceOrder)
   at Microsoft.PowerShell.CommandLineParameterParser.GetConfigurationNameFromGroupPolicy()
   at Microsoft.PowerShell.ConsoleHost.ParseCommandLine(String[] args)
   at Microsoft.PowerShell.UnmanagedPSEntry.Start(String[] args, Int32 argc)
   at Microsoft.PowerShell.ManagedPSEntry.Main(String[] args)

```